### PR TITLE
Dropwizard Percentiles -> CloudWatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.amazonaws:aws-java-sdk-cloudwatch:1.9.18'
-    compile 'io.dropwizard.metrics:metrics-core:3.1.0'
+    compile 'com.amazonaws:aws-java-sdk-cloudwatch:1.10.19'
+    compile 'io.dropwizard.metrics:metrics-core:3.1.2'
 
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
I added the ability to pass in percentiles (or use hopefully sane defaults) that a caller wants to track for Sampling metrics.  Currently, it creates a new CloudWatch MetricDatum (StatisticSet) for each of the DemuxedKey names, extending the "type" with .p{percentile} -- e.g. com.example.getUserById.p995 for the 99.5th percentile.

The percentile configuration resulted in a bit of a constructor explosion, but I didn't want to break existing constructors.  Perhaps using Guava Optionals for the optional parameters would be a better approach, but doing that across the board would result in some non-backward compatible changes, and I wasn't sure how open this project is to that.

I'd love to get feedback and thoughts on improvements/modifications.